### PR TITLE
Use r1666 from the repository instead of HEAD

### DIFF
--- a/files/brews/gyp.rb
+++ b/files/brews/gyp.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Gyp < Formula
   homepage 'http://code.google.com/p/gyp/'
-  head 'http://gyp.googlecode.com/svn/trunk'
+  head 'http://gyp.googlecode.com/svn/trunk@1666'
 
   depends_on 'scons'
 


### PR DESCRIPTION
r1666 installs a working version of gyp, HEAD is broken pending http://code.google.com/p/gyp/issues/detail?id=362

I don’t know what turn around my patch will have upstream, it might be worth merging this until upstream is fixed, I can revert this and track HEAD again when it’s merged

/cc @wfarr
