### PR TITLE
Remove the gyp moving and symlinking

### DIFF
--- a/files/brews/gyp.rb
+++ b/files/brews/gyp.rb
@@ -3,6 +3,7 @@ require 'formula'
 class Gyp < Formula
   homepage 'http://code.google.com/p/gyp/'
   head 'http://gyp.googlecode.com/svn/trunk', :revision => '1666'
+
   depends_on 'scons'
 
   def install
@@ -16,9 +17,5 @@ class Gyp < Formula
                      "--install-purelib=#{libexec}",
                      "--install-platlib=#{libexec}",
                      "--install-scripts=#{bin}"
-
-    # Shift files around to avoid needing a PYTHONPATH
-    mv bin+'gyp', "#{libexec}/gyp.py"
-    bin.install_symlink "#{libexec}/gyp.py" => "gyp"
   end
 end


### PR DESCRIPTION
Per the comment this is supposed to fix PYTHONPATH issues but actually ends up making libexec/gyp.py the file that’s loaded when the script runs `import gyp` because it’s named gyp.py and in the same directory as the running script, see http://docs.python.org/2/tutorial/modules.html#the-module-search-path. `gyp.main` is looked up in the wrong file leading to errors of the form

``` bash
Traceback (most recent call last):
  File "/opt/boxen/homebrew/bin/gyp", line 18, in <module>
    sys.exit(gyp.main(sys.argv[1:]))
AttributeError: 'module' object has no attribute 'main'
```

By not having the file named gyp.py ahead of the actual module in site-packages directory, `import gyp` loads the correct file
